### PR TITLE
fix(supabase): limit service key usage to privileged server code (#17)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
-import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
 
 async function getStats() {
-  const supabase = createClient();
+  const supabase = createServiceRoleClient();
   
   // Get photo count
   const { count: photoCount } = await supabase

--- a/src/app/api/admin/categories/[id]/route.ts
+++ b/src/app/api/admin/categories/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
 import { isAdminAuthenticated } from '@/lib/auth/admin';
 
 // Update category
@@ -12,7 +12,7 @@ export async function PUT(
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const body = await request.json();
     const { id } = params;
     
@@ -52,7 +52,7 @@ export async function DELETE(
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const { id } = params;
     
     // Check if category has photos

--- a/src/app/api/admin/categories/route.ts
+++ b/src/app/api/admin/categories/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
 import { isAdminAuthenticated } from '@/lib/auth/admin';
 
 // Create new category
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const body = await request.json();
     
     const { name, description, display_order } = body;

--- a/src/app/api/admin/photos/[id]/route.ts
+++ b/src/app/api/admin/photos/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
 import { isAdminAuthenticated } from '@/lib/auth/admin';
 import { deleteImage } from '@/lib/storage';
 import { triggerRevalidation } from '@/lib/revalidate';
@@ -15,7 +15,7 @@ export async function PUT(
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const body = await request.json();
     const { id } = params;
     
@@ -59,7 +59,7 @@ export async function DELETE(
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const { id } = params;
     
     // Get photo details first

--- a/src/app/api/admin/photos/reorder/route.ts
+++ b/src/app/api/admin/photos/reorder/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
 import { isAdminAuthenticated } from '@/lib/auth/admin';
 import { triggerRevalidation } from '@/lib/revalidate';
 
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   }
   
   try {
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     const { photoIds } = await request.json();
     
     if (!Array.isArray(photoIds)) {

--- a/src/app/api/photos/upload/route.ts
+++ b/src/app/api/photos/upload/route.ts
@@ -11,7 +11,7 @@
  */
 import { Buffer } from 'node:buffer';
 import { NextRequest, NextResponse } from 'next/server'; // Next.js server utilities.
-import { createClient } from '@/lib/supabase-server'; // Server-side Supabase client.
+import { createServiceRoleClient } from '@/lib/supabase-server'; // Server-side Supabase client.
 import {
   extractExifData,
   ALLOWED_IMAGE_TYPES,
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const supabase = createClient();
+    const supabase = createServiceRoleClient();
     
     const formData = await request.formData(); // Parse multipart/form-data.
     

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,6 @@
 import type { Buffer } from 'node:buffer';
 import { createClient } from './supabase-client';
-import { createClient as createServerClient } from './supabase-server';
+import { createServiceRoleClient } from './supabase-server';
 import { CreatePhotoInput } from './types';
 import exifr from 'exifr';
 
@@ -115,7 +115,7 @@ export async function uploadImage(
   bucket: string = PHOTOS_BUCKET,
   isServer: boolean = false
 ): Promise<{ path: string; publicUrl: string }> {
-  const supabase = isServer ? createServerClient() : createClient();
+  const supabase = isServer ? createServiceRoleClient() : createClient();
   
   // Validate file type
   if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
@@ -169,7 +169,7 @@ export async function deleteImage(
   bucket: string = PHOTOS_BUCKET,
   isServer: boolean = false
 ): Promise<void> {
-  const supabase = isServer ? createServerClient() : createClient();
+  const supabase = isServer ? createServiceRoleClient() : createClient();
   
   const { error } = await supabase.storage
     .from(bucket)
@@ -224,7 +224,7 @@ export async function uploadImageFromBuffer({
   contentType,
   extension,
 }: UploadBufferOptions): Promise<{ path: string; publicUrl: string }> {
-  const supabase = createServerClient();
+  const supabase = createServiceRoleClient();
   const filename = generateStorageFilename(`upload.${extension}`);
   const path = `${new Date().getFullYear()}/${filename}`;
 


### PR DESCRIPTION
- split supabase server helper into anon vs service-role clients and remove the fallback to anon when the service key is missing
- update admin APIs, SSR dashboard, and storage uploads to require the service role client only where privileged access is needed
- keep public code paths on anon clients so RLS remains enforced

# Pull Request: Fix Portfolio Page Server Rendering

## 🎯 Summary
Fixes the critical production issue where the portfolio page shows "Loading gallery..." indefinitely.

## 🔧 Changes Made

### Core Fix
- **Converted portfolio page from client to server component**
  - Removed `'use client'` directive and `useEffect` hooks
  - Implemented server-side data fetching with Supabase
  - Added ISR (Incremental Static Regeneration) with 1-hour cache

### Supporting Improvements
- **Added error handling**
  - Created `error.tsx` boundary for graceful failures
  - Handles Supabase connection issues
  - Provides user-friendly error messages
  
- **Added loading states**
  - Created `loading.tsx` with skeleton UI
  - Matches the design aesthetic
  - Improves perceived performance

- **Fixed type inconsistencies**
  - Standardized on `is_black_white` field
  - Updated TypeScript interfaces
  - Aligned with database schema

### Developer Experience
- **Created project tracking**
  - Added `.github/ISSUES_TEMPLATE.md` with 12 prioritized issues
  - Added `.github/PROJECT_STATUS.md` for work continuity
  - Created environment checking script

## 📝 Testing Checklist

- [x] Build succeeds locally (`npm run build`)
- [x] No TypeScript errors
- [x] Portfolio page renders without client-side fetching
- [ ] Tested in production environment
- [ ] Verified with real Supabase data

## 🚀 Deployment Steps

1. **Merge this PR**
2. **Configure Vercel environment variables** (Critical!)
   ```
   NEXT_PUBLIC_SUPABASE_URL=your-url
   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
   SUPABASE_SERVICE_ROLE_KEY=your-service-key
   ```
3. **Deploy to Vercel**
4. **Verify portfolio loads correctly**

## 🔍 Before/After

### Before (Client Component)
```typescript
'use client';
// Used useEffect to fetch data
// Resulted in infinite loading spinner
```

### After (Server Component)
```typescript
// Server-side data fetching
// ISR with revalidate = 3600
// Immediate render, no spinner
```

## 📊 Performance Impact

- **TTFB**: Improved (server-rendered)
- **LCP**: Faster (no client-side wait)
- **CLS**: Zero (proper loading skeleton)
- **SEO**: Better (server-side rendered content)

## 🐛 Fixes Issue

Resolves: Portfolio page stuck showing "Loading gallery..." in production

## 📋 Next Steps

After merging:
1. Configure environment variables in Vercel
2. Monitor for any edge cases
3. Consider adding:
   - Blur placeholders for images
   - On-demand revalidation webhook
   - More granular error handling

## 📚 Documentation

- Project status: `.github/PROJECT_STATUS.md`
- Issues backlog: `.github/ISSUES_TEMPLATE.md`
- Env setup: `scripts/check-env.sh`

---

**Ready for review and merge!** 🎉
