### PR TITLE
feat(home): refresh hero messaging and about/contact row (#28/#29)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -102,7 +102,7 @@ export default async function Home() {
       {/* About and Contact Section: Provides brief introductions and links. */}
       <section className="py-16 bg-primary-beige">
         <div className="container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
             {/* About Me Card */}
             <Card variant="white" withGrain={true} title="ABOUT ME">
               <div className="flex flex-col md:flex-row gap-6 items-center mb-6">
@@ -149,7 +149,26 @@ export default async function Home() {
               {/* Link to the full "Contact Me" page. */}
               <div className="text-center">
                 <Button href="/contact" variant="tertiary">
-                  Contact Me
+                Contact Me
+              </Button>
+            </div>
+            </Card>
+
+            {/* Gear Teaser Card */}
+            <Card variant="white" withGrain={true} title="GEAR TEASER">
+              <p className="leading-relaxed text-primary-charcoal mb-6">
+                Hasselblad 500C. Rolleiflex 3.5. Hand-loaded Portra. The tools shape the tones,
+                and we’re documenting the process in a new gear showcase inspired by
+                teenage.engineering quick guides.
+              </p>
+              <ul className="text-sm text-primary-charcoal/80 space-y-2 mb-6">
+                <li>• Line-art callouts for each camera</li>
+                <li>• Film stocks, lenses, and workflow tips</li>
+                <li>• Quick-guide panels for portrait & street sessions</li>
+              </ul>
+              <div className="text-center">
+                <Button href="/portfolio#gear" variant="outline">
+                  Preview Coming Soon
                 </Button>
               </div>
             </Card>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -88,6 +88,7 @@ export default async function Home() {
           gap="large" // Spacing between gallery items.
           aspectRatio="square" // Aspect ratio for the gallery images.
           withHoverEffect={true} // Enables a hover effect on gallery items.
+          frameStyle="film" // Display as stylised film frames.
           className="mb-12" // Additional styling for the gallery container.
         />
         

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -15,6 +15,7 @@ export interface GalleryProps { // Added export for consistency, though not stri
   gap?: 'none' | 'small' | 'medium' | 'large';
   aspectRatio?: 'square' | 'landscape' | 'portrait';
   withHoverEffect?: boolean;
+  frameStyle?: 'default' | 'film';
   className?: string;
 }
 
@@ -24,6 +25,7 @@ const Gallery = ({
   gap = 'medium',
   aspectRatio = 'square',
   withHoverEffect = true,
+  frameStyle = 'default',
   className = ''
 }: GalleryProps) => {
   const [isLoading, setIsLoading] = useState<Record<number, boolean>>({});
@@ -62,7 +64,33 @@ const Gallery = ({
     <div className={`grid ${columnMap[columns]} ${gapMap[gap]} ${className}`}>
       {images.map((image, index) => (
         <div key={index} className="group transform transition-transform duration-500 hover:-translate-y-1">
-          <div className={`relative overflow-hidden ${aspectRatioMap[aspectRatio]} shadow-lg rounded-sm border-2 border-gray-100`}>
+          <div
+            className={`relative overflow-hidden ${aspectRatioMap[aspectRatio]} ${
+              frameStyle === 'film'
+                ? 'rounded-[18px] border border-primary-charcoal/40 bg-primary-charcoal shadow-2xl'
+                : 'shadow-lg rounded-sm border-2 border-gray-100'
+            }`}
+          >
+            {frameStyle === 'film' && (
+              <>
+                <div className="absolute inset-x-0 top-0 flex h-6 items-center justify-around bg-primary-charcoal">
+                  {Array.from({ length: 5 }).map((_, sprocketIndex) => (
+                    <span
+                      key={`top-${sprocketIndex}`}
+                      className="h-4 w-3 rounded-[1px] bg-secondary-offWhite/90"
+                    />
+                  ))}
+                </div>
+                <div className="absolute inset-x-0 bottom-0 flex h-6 items-center justify-around bg-primary-charcoal">
+                  {Array.from({ length: 5 }).map((_, sprocketIndex) => (
+                    <span
+                      key={`bottom-${sprocketIndex}`}
+                      className="h-4 w-3 rounded-[1px] bg-secondary-offWhite/90"
+                    />
+                  ))}
+                </div>
+              </>
+            )}
             {/* Loading placeholder */}
             {!isLoading[index] && (
               <div className="absolute inset-0 bg-gray-200 animate-pulse" />
@@ -84,6 +112,14 @@ const Gallery = ({
               `}
               onLoad={() => handleImageLoad(index)}
             />
+
+            {frameStyle === 'film' && (
+              <div className="absolute bottom-9 right-5 rounded bg-primary-charcoal/80 px-3 py-1">
+                <span className="text-xs font-mono uppercase tracking-[0.35em] text-primary-mauve">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+              </div>
+            )}
           </div>
           
           {/* Enhanced caption display */}

--- a/src/components/home/FilmstripBanner.tsx
+++ b/src/components/home/FilmstripBanner.tsx
@@ -104,10 +104,10 @@ export default function FilmstripBanner({ photos, introLine }: FilmstripBannerPr
             filmstrip diary
           </span>
           <h1 className="mt-3 text-4xl md:text-5xl lg:text-6xl font-bold text-primary-charcoal retro-font drop-shadow-[0_3px_12px_rgba(255,255,255,0.35)]">
-            TONAL FOCUS
+            Medium-Format Stories
           </h1>
           <p className="mt-4 max-w-xl text-base md:text-lg text-primary-charcoal/85 backdrop-blur-sm bg-secondary-offWhite/70 px-4 py-2 rounded-sm">
-            {introLine ?? 'Medium-format film work, hand-picked each week from the Tonal Focus archive.'}
+            {introLine ?? 'Hand-picked frames from the Tonal Focus archive—curated weekly.'}
           </p>
         </div>
 

--- a/src/components/home/FilmstripBanner.tsx
+++ b/src/components/home/FilmstripBanner.tsx
@@ -95,20 +95,21 @@ export default function FilmstripBanner({ photos, introLine }: FilmstripBannerPr
       className={isMobile ? '' : 'h-[400vh] relative w-full'}
     >
       <div className={isMobile ? '' : 'sticky top-0 h-screen w-full overflow-hidden flex flex-col justify-center'}>
-        {/* Header Text */}
+        {/* Header Chip */}
         <div
-          className={`${isMobile ? 'relative pt-10' : 'absolute top-0 left-0'} w-full px-8 md:px-16 pt-12 md:pt-16 pb-6 z-10 pointer-events-none`}
+          className={`${
+            isMobile
+              ? 'relative pt-10 flex justify-center'
+              : 'absolute top-10 left-16'
+          } w-full px-8 md:px-0 z-10 pointer-events-none`}
         >
-          <span className="inline-flex items-center gap-3 text-[11px] tracking-[0.4em] uppercase text-primary-mauve/70">
+          <span
+            className="inline-flex items-center gap-3 rounded-full bg-secondary-offWhite/80 px-4 py-2 text-[11px] uppercase tracking-[0.4em] text-primary-mauve/80 shadow-sm"
+            title={introLine ?? undefined}
+          >
             <span className="h-px w-12 bg-primary-mauve/40" aria-hidden />
             filmstrip diary
           </span>
-          <h1 className="mt-3 text-4xl md:text-5xl lg:text-6xl font-bold text-primary-charcoal retro-font drop-shadow-[0_3px_12px_rgba(255,255,255,0.35)]">
-            Medium-Format Stories
-          </h1>
-          <p className="mt-4 max-w-xl text-base md:text-lg text-primary-charcoal/85 backdrop-blur-sm bg-secondary-offWhite/70 px-4 py-2 rounded-sm">
-            {introLine ?? 'Hand-picked frames from the Tonal Focus archive—curated weekly.'}
-          </p>
         </div>
 
         {/* Filmstrip */}

--- a/src/components/home/FilmstripBanner.tsx
+++ b/src/components/home/FilmstripBanner.tsx
@@ -6,9 +6,10 @@ import { Photo } from '@/lib/types';
 
 interface FilmstripBannerProps {
   photos: Photo[];
+  introLine?: string;
 }
 
-export default function FilmstripBanner({ photos }: FilmstripBannerProps) {
+export default function FilmstripBanner({ photos, introLine }: FilmstripBannerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const filmstripRef = useRef<HTMLDivElement>(null);
   const [isMobile, setIsMobile] = useState(false);
@@ -95,12 +96,18 @@ export default function FilmstripBanner({ photos }: FilmstripBannerProps) {
     >
       <div className={isMobile ? '' : 'sticky top-0 h-screen w-full overflow-hidden flex flex-col justify-center'}>
         {/* Header Text */}
-        <div className={`${isMobile ? 'relative pt-8' : 'absolute top-0 left-0'} w-full p-8 md:p-12 z-10`}>
-          <h1 className="text-4xl md:text-5xl font-bold text-primary-charcoal retro-font">
+        <div
+          className={`${isMobile ? 'relative pt-10' : 'absolute top-0 left-0'} w-full px-8 md:px-16 pt-12 md:pt-16 pb-6 z-10 pointer-events-none`}
+        >
+          <span className="inline-flex items-center gap-3 text-[11px] tracking-[0.4em] uppercase text-primary-mauve/70">
+            <span className="h-px w-12 bg-primary-mauve/40" aria-hidden />
+            filmstrip diary
+          </span>
+          <h1 className="mt-3 text-4xl md:text-5xl lg:text-6xl font-bold text-primary-charcoal retro-font drop-shadow-[0_3px_12px_rgba(255,255,255,0.35)]">
             TONAL FOCUS
           </h1>
-          <p className="text-lg md:text-xl text-primary-mauve mt-2">
-            Film Photography | B&W | Color
+          <p className="mt-4 max-w-xl text-base md:text-lg text-primary-charcoal/85 backdrop-blur-sm bg-secondary-offWhite/70 px-4 py-2 rounded-sm">
+            {introLine ?? 'Medium-format film work, hand-picked each week from the Tonal Focus archive.'}
           </p>
         </div>
 
@@ -109,7 +116,7 @@ export default function FilmstripBanner({ photos }: FilmstripBannerProps) {
           ref={filmstripRef}
           className={`
             ${isMobile ? 'flex flex-col w-full items-center' : 'flex items-center w-max'}
-            ${!isMobile && 'pl-[calc((100vw-600px)/2)]'}
+            ${!isMobile && 'pl-[calc((100vw-760px)/2)]'}
           `}
           style={{ willChange: 'transform' }}
         >
@@ -124,13 +131,14 @@ export default function FilmstripBanner({ photos }: FilmstripBannerProps) {
                 relative overflow-hidden
                 ${
                   isMobile
-                    ? 'w-[85vw] h-[85vw] my-8'
-                    : 'w-[min(820px,65vw)] h-[min(70vh,820px)]'
+                    ? 'w-[70vw] h-[70vw] my-8'
+                    : 'w-[min(780px,58vw)] h-[min(68vh,780px)]'
                 }
                 flex-shrink-0
               `}
             >
               <div className="relative w-full h-full group">
+                <span className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-primary-beige/40 via-transparent to-transparent" aria-hidden />
                 {/* Film perforation effect - top */}
                 <div className="absolute top-0 left-0 right-0 h-8 bg-primary-charcoal z-10 flex justify-around items-center">
                   {[...Array(6)].map((_, i) => (
@@ -146,7 +154,7 @@ export default function FilmstripBanner({ photos }: FilmstripBannerProps) {
                 </div>
 
                 {/* Photo */}
-                <div className="absolute inset-0 flex items-center justify-center bg-primary-charcoal p-8">
+                <div className="absolute inset-0 flex items-center justify-center bg-primary-charcoal p-6 lg:p-8">
                   <Image
                     src={imageSrc}
                     alt={altText}

--- a/src/components/home/FilmstripBanner.tsx
+++ b/src/components/home/FilmstripBanner.tsx
@@ -124,6 +124,7 @@ export default function FilmstripBanner({ photos, introLine }: FilmstripBannerPr
           {photos.map((photo, index) => {
             const imageSrc = photo.public_url || photo.thumbnail_url || '/images/gallery1.jpg';
             const altText = photo.title || `Featured photo ${index + 1}`;
+            const isPriorityFrame = index < 3;
 
             return (
             <div
@@ -162,9 +163,9 @@ export default function FilmstripBanner({ photos, introLine }: FilmstripBannerPr
                     width={1200}
                     height={1200}
                     className="w-full h-full object-cover rounded-lg shadow-2xl"
-                    priority={index < 3}
+                    priority={isPriorityFrame}
                     quality={index === 0 ? 95 : 90}
-                    loading={index === 0 ? 'eager' : 'lazy'}
+                    loading={isPriorityFrame ? undefined : 'lazy'}
                     sizes="(max-width: 600px) 85vw, (max-width: 1200px) 65vw, 820px"
                   />
                 </div>

--- a/src/components/home/FilmstripBannerWrapper.tsx
+++ b/src/components/home/FilmstripBannerWrapper.tsx
@@ -1,6 +1,24 @@
 import FilmstripBanner from './FilmstripBanner';
 import { createPublicClient } from '@/lib/supabase-public';
 
+function buildIntroLine(photos: any[]): string | undefined {
+  if (!photos || photos.length === 0) return undefined;
+  const leading = photos[0];
+  const category = leading?.category?.name;
+  const title = leading?.title;
+  const count = photos.length;
+
+  if (category && title) {
+    return `${category.toUpperCase()} · Now playing: ${title}`;
+  }
+
+  if (title) {
+    return `${count} featured frames · ${title}`;
+  }
+
+  return `${count} featured frames from the Tonal Focus archive.`;
+}
+
 export default async function FilmstripBannerWrapper() {
   try {
     const supabase = createPublicClient();
@@ -8,7 +26,7 @@ export default async function FilmstripBannerWrapper() {
     // Fetch featured photos for the filmstrip
     const { data: photos, error } = await supabase
       .from('photos')
-      .select('*')
+      .select(`*, category:categories(name)`) 
       .eq('is_featured', true)
       .order('display_order', { ascending: true })
       .limit(6);
@@ -23,7 +41,7 @@ export default async function FilmstripBannerWrapper() {
     if (!photos || photos.length === 0) {
       const { data: latestPhotos, error: latestError } = await supabase
         .from('photos')
-        .select('*')
+        .select('*, category:categories(name)')
         .order('created_at', { ascending: false })
         .limit(6);
 
@@ -32,10 +50,10 @@ export default async function FilmstripBannerWrapper() {
         return <FilmstripBanner photos={[]} />;
       }
 
-      return <FilmstripBanner photos={latestPhotos || []} />;
+      return <FilmstripBanner photos={latestPhotos || []} introLine={buildIntroLine(latestPhotos || [])} />;
     }
 
-    return <FilmstripBanner photos={photos} />;
+    return <FilmstripBanner photos={photos} introLine={buildIntroLine(photos)} />;
   } catch (error) {
     console.error('Error in FilmstripBannerWrapper:', error);
     // Return empty array on any error


### PR DESCRIPTION
- add filmstrip diary header, gradient, and dynamic intro line for featured rotation
- tighten hero frame sizing and styling for better UX
- collapse about/contact into a single three-column row with gear teaser

# Pull Request: Fix Portfolio Page Server Rendering

## 🎯 Summary
Fixes the critical production issue where the portfolio page shows "Loading gallery..." indefinitely.

## 🔧 Changes Made

### Core Fix
- **Converted portfolio page from client to server component**
  - Removed `'use client'` directive and `useEffect` hooks
  - Implemented server-side data fetching with Supabase
  - Added ISR (Incremental Static Regeneration) with 1-hour cache

### Supporting Improvements
- **Added error handling**
  - Created `error.tsx` boundary for graceful failures
  - Handles Supabase connection issues
  - Provides user-friendly error messages
  
- **Added loading states**
  - Created `loading.tsx` with skeleton UI
  - Matches the design aesthetic
  - Improves perceived performance

- **Fixed type inconsistencies**
  - Standardized on `is_black_white` field
  - Updated TypeScript interfaces
  - Aligned with database schema

### Developer Experience
- **Created project tracking**
  - Added `.github/ISSUES_TEMPLATE.md` with 12 prioritized issues
  - Added `.github/PROJECT_STATUS.md` for work continuity
  - Created environment checking script

## 📝 Testing Checklist

- [x] Build succeeds locally (`npm run build`)
- [x] No TypeScript errors
- [x] Portfolio page renders without client-side fetching
- [ ] Tested in production environment
- [ ] Verified with real Supabase data

## 🚀 Deployment Steps

1. **Merge this PR**
2. **Configure Vercel environment variables** (Critical!)
   ```
   NEXT_PUBLIC_SUPABASE_URL=your-url
   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
   SUPABASE_SERVICE_ROLE_KEY=your-service-key
   ```
3. **Deploy to Vercel**
4. **Verify portfolio loads correctly**

## 🔍 Before/After

### Before (Client Component)
```typescript
'use client';
// Used useEffect to fetch data
// Resulted in infinite loading spinner
```

### After (Server Component)
```typescript
// Server-side data fetching
// ISR with revalidate = 3600
// Immediate render, no spinner
```

## 📊 Performance Impact

- **TTFB**: Improved (server-rendered)
- **LCP**: Faster (no client-side wait)
- **CLS**: Zero (proper loading skeleton)
- **SEO**: Better (server-side rendered content)

## 🐛 Fixes Issue

Resolves: Portfolio page stuck showing "Loading gallery..." in production

## 📋 Next Steps

After merging:
1. Configure environment variables in Vercel
2. Monitor for any edge cases
3. Consider adding:
   - Blur placeholders for images
   - On-demand revalidation webhook
   - More granular error handling

## 📚 Documentation

- Project status: `.github/PROJECT_STATUS.md`
- Issues backlog: `.github/ISSUES_TEMPLATE.md`
- Env setup: `scripts/check-env.sh`

---

**Ready for review and merge!** 🎉
